### PR TITLE
Added the strict parameter to the `in_array` function that checks if the 

### DIFF
--- a/controllers/components/batch.php
+++ b/controllers/components/batch.php
@@ -90,7 +90,7 @@ class BatchComponent extends Object {
 			$this->settings = array_merge($this->settings, $settings);
 			
 			// Fix for security component
-			if ($this->settings['security'] && in_array('Security', array_keys($controller->components))) {
+			if ($this->settings['security'] && in_array('Security', array_keys($controller->components), true)) {
 				$controller->Security->disabledFields = array_merge($controller->Security->disabledFields, array(
 					'Filter.filter', 
 					'Filter.reset',


### PR DESCRIPTION
Added the strict parameter to the `in_array` function that checks if the Security component is used. Without it, the Batch plugin sometimes recognize that the Security component is used when it's not... on my setup at least.
