### PR TITLE
Forcing empty attributes on the "check-all" checkbox

### DIFF
--- a/views/helpers/batch.php
+++ b/views/helpers/batch.php
@@ -242,6 +242,8 @@ class BatchHelper extends Helper {
 	function all($options = array()) {
 		$options = array_merge(array(
 			'value' => '', 
+			'id' => '',
+			'name' => '',
 			'hiddenField' => false, 
 			'class' => 'batch-all'
 		), $options);


### PR DESCRIPTION
Depending on where I place this checkbox in my table, the `id` and `name` attributes can be automatically filled with other inputs values and cause conflicts. Forcing empty fields prevent that from happening.
