### PR TITLE
Added 'string' field type support

### DIFF
--- a/View/Helper/BatchHelper.php
+++ b/View/Helper/BatchHelper.php
@@ -232,6 +232,7 @@ class BatchHelper extends Helper {
 			$model = $this->model;
 		}
 		switch ($this->_fieldType($model, $field)) {
+			case 'string':
 			case 'text':
 				$options += array('type' => 'text');
 			break;


### PR DESCRIPTION
Fixed:
FormHelper generates select if is set variable for field 
example: `field`:`domain_id`; `var`:`domains`
